### PR TITLE
feat: add simulate verify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "ethers": "^6.6.2",
         "json-bigint": "^1.0.0"
       },
       "devDependencies": {
@@ -27,7 +28,6 @@
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^3.4.0",
-        "ethers": "^6.6.2",
         "hardhat": "^2.16.1",
         "husky": "^6.0.0",
         "jest": "^29.6.1",
@@ -52,8 +52,7 @@
     "node_modules/@adraffy/ens-normalize": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.2.tgz",
-      "integrity": "sha512-0h+FrQDqe2Wn+IIGFkTCd4aAwTJ+7834Ek1COohCyV26AXhwQ7WQaz+4F/nLOeVl/3BtWHOHLPsq46V8YB46Eg==",
-      "dev": true
+      "integrity": "sha512-0h+FrQDqe2Wn+IIGFkTCd4aAwTJ+7834Ek1COohCyV26AXhwQ7WQaz+4F/nLOeVl/3BtWHOHLPsq46V8YB46Eg=="
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.1",
@@ -3626,7 +3625,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
       "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -3638,7 +3636,6 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
       "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -5872,8 +5869,7 @@
     "node_modules/aes-js": {
       "version": "4.0.0-beta.5",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
-      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
-      "dev": true
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
@@ -9546,7 +9542,6 @@
       "version": "6.6.2",
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.6.2.tgz",
       "integrity": "sha512-vyWfVAj2g7xeZIivOqlbpt7PbS2MzvJkKgsncgn4A/1xZr8Q3BznBmEBRQyPXKCgHmX4PzRQLpnYG7jl/yutMg==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -9573,8 +9568,7 @@
     "node_modules/ethers/node_modules/@types/node": {
       "version": "18.15.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
-      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==",
-      "dev": true
+      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q=="
     },
     "node_modules/ethjs-unit": {
       "version": "0.1.6",
@@ -24189,8 +24183,7 @@
     "node_modules/tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/tsort": {
       "version": "0.0.1",
@@ -25058,7 +25051,6 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
       "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prepare": "husky install",
     "semantic-release": "semantic-release",
     "test:watch": "jest --watch",
-    "test": "jest --coverage",
+    "test": "jest --coverage --detectOpenHandles",
     "typecheck": "tsc --noEmit"
   },
   "author": "Jason Morton",
@@ -42,10 +42,10 @@
     "ts-node": "^10.2.1",
     "typescript": "^5.1.6",
     "@typechain/hardhat": "^8.0.0",
-    "ethers": "^6.6.2",
     "json-bigint": "^1.0.0"
   },
   "dependencies": {
-    "json-bigint": "^1.0.0"
+    "json-bigint": "^1.0.0",
+    "ethers": "^6.6.2"
   }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,1 +1,3 @@
+import { ethers } from 'ethers';
 export declare function parseProof(proofFilePath: string): [bigint[], string];
+export declare function simulateVerify(pubInputs: bigint[], proof: string, provider: ethers.Provider, contractAddress: string, abi: ethers.InterfaceAbi): Promise<boolean>;

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.parseProof = void 0;
+exports.simulateVerify = exports.parseProof = void 0;
+const ethers_1 = require("ethers");
 const fs = __importStar(require("fs"));
 const JSONBig = __importStar(require("json-bigint"));
 function vecu64ToField(b) {
@@ -56,3 +57,10 @@ function parseProof(proofFilePath) {
     return [publicInputs, '0x' + proof.proof];
 }
 exports.parseProof = parseProof;
+async function simulateVerify(pubInputs, proof, provider, contractAddress, abi) {
+    // Initialize provider and contract
+    const contract = new ethers_1.Contract(contractAddress, abi, provider);
+    const result = await contract.verify(pubInputs, proof);
+    return result;
+}
+exports.simulateVerify = simulateVerify;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { ethers, Contract } from 'ethers';
 import * as fs from 'fs';
 import * as JSONBig from 'json-bigint';
 
@@ -38,4 +39,17 @@ export function parseProof(proofFilePath: string): [bigint[], string] {
 
   const publicInputs = instances.flat();
   return [publicInputs, '0x' + proof.proof];
+}
+
+export async function simulateVerify(
+  pubInputs: bigint[],
+  proof: string,
+  provider: ethers.Provider,
+  contractAddress: string,
+  abi: ethers.InterfaceAbi
+): Promise<boolean> {
+  // Initialize provider and contract
+  const contract = new Contract(contractAddress, abi, provider);
+  const result: boolean = await contract.verify(pubInputs, proof);
+  return result;
 }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,28 +1,65 @@
-import { parseProof } from '../src';
+import { parseProof, simulateVerify } from '../src';
 import { ethers } from 'hardhat';
 import { Verifier } from '../test/typechain-types/Verifier';
 import { assert } from 'ethers';
 
 describe('ezkl', () => {
+  let Verifier: Verifier;
+  let proofPath: string = "./test/data/test.pf"
+  let rpc_url: string = "http://127.0.0.1:8545/"
+  beforeAll(async () => {
+    // Instantiate contract
+    Verifier = await ethers.deployContract("Verifier");
+  });
   describe('parseProof', () => {
     it('should return pubInputs and proof from test.pf file', async() => {
 
-      let proofPath = "./test/data/test.pf"
-
       let [pubInputs, proof] = parseProof(proofPath);
-    
-      // Instantiate contract
-      let Verifier: Verifier
-  
-      Verifier = await ethers.deployContract("Verifier")
-  
+
       console.info("publicInputs: ", pubInputs);
       console.info("proof: ", proof);
   
       // Call verify function and return results
       const result = await Verifier.verify(pubInputs, proof);
 
-      assert(result == true, "Parsing worked", "BAD_DATA");
+      assert(result == true, "Proof parsing worked", "BAD_DATA");
     });
   });
+  describe('simulateVerify', () => {
+    it('should return true for test.pf file', async() => {
+      let address = await Verifier.getAddress();
+      // get provider
+      let provider = ethers.provider;
+      let abi = [
+        {
+          "inputs": [
+            {
+              "internalType": "uint256[]",
+              "name": "pubInputs",
+              "type": "uint256[]"
+            },
+            {
+              "internalType": "bytes",
+              "name": "proof",
+              "type": "bytes"
+            }
+          ],
+          "name": "verify",
+          "outputs": [
+            {
+              "internalType": "bool",
+              "name": "",
+              "type": "bool"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        }
+      ]
+      console.log(proofPath)
+      let [pubInputs, proof] = parseProof(proofPath);
+      let result = await simulateVerify(pubInputs, proof, provider, address, abi);
+      assert(result == true, "Simulate verify worked", "BAD_DATA");
+    });
+  })
 });


### PR DESCRIPTION
- Simulates a verify call on a given rpc endpoint. 
- Useful for checking on client side apps if your prover and evm verifier are behaving according to expectation.