### PR TITLE
feat: add access token and api key to gated endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ezkljs/hub",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/src/api/genArtifact.ts
+++ b/src/api/genArtifact.ts
@@ -8,6 +8,7 @@ import {
 } from '@/utils/parsers'
 import request from '@/utils/request'
 import { z } from 'zod'
+import authHeaders from '@/utils/authHeaders'
 
 type GenArtifactOptions = {
   name: string
@@ -47,8 +48,6 @@ export default async function genArtifact({
   const validatedName = z.string().parse(name)
   const validatedDescription = z.string().parse(description)
   const validatedOrganizationId = uuidSchema.parse(organizationId)
-  let validatedAccessToken = null
-  let validatedApiKey = null
 
   const validatedUncompiledModelFile =
     fileOrBufferSchema.parse(uncompiledModelFile)
@@ -76,16 +75,7 @@ export default async function genArtifact({
   body.append('uncompiledModel', new Blob([validatedUncompiledModelFile]))
   body.append('input', new Blob([validatedInputFile]))
 
-  const headers = new Headers()
-
-  if (accessToken) {
-    validatedAccessToken = z.string().parse(accessToken)
-    headers.append('Authorization', `Bearer ${validatedAccessToken}`)
-  }
-  if (apiKey) {
-    validatedApiKey = z.string().parse(apiKey)
-    headers.append('API-Key', validatedApiKey)
-  }
+  const headers = authHeaders(apiKey, accessToken)
 
   try {
     const genArtifactResponse = await request<unknown>(url, {

--- a/src/api/uploadArtifact.ts
+++ b/src/api/uploadArtifact.ts
@@ -9,6 +9,7 @@ import {
 } from '@/utils/parsers'
 import request from '@/utils/request'
 import { z } from 'zod'
+import authHeaders from '@/utils/authHeaders'
 
 type UploadArtifactOptions = {
   name: string
@@ -56,8 +57,6 @@ export default async function uploadArtifact({
   const validatedPkFile = fileOrBufferSchema.parse(pkFile)
   const validatedOrganizationId = uuidSchema.parse(organizationId)
   const validatedUrl = urlSchema.parse(url)
-  let validatedAccessToken = null
-  let validatedApiKey = null
 
   const operations = {
     query: UPLOAD_ARTIFACTE_MUTATION,
@@ -84,16 +83,7 @@ export default async function uploadArtifact({
   body.append('settings', new Blob([validatedSettingsFile]))
   body.append('pk', new Blob([validatedPkFile]))
 
-  const headers = new Headers()
-
-  if (accessToken) {
-    validatedAccessToken = z.string().parse(accessToken)
-    headers.append('Authorization', `Bearer ${validatedAccessToken}`)
-  }
-  if (apiKey) {
-    validatedApiKey = z.string().parse(apiKey)
-    headers.append('API-Key', validatedApiKey)
-  }
+  const headers = authHeaders(apiKey, accessToken)
 
   try {
     const uploadArtifactResponse = await request<unknown>(validatedUrl, {

--- a/src/api/uploadArtifact.ts
+++ b/src/api/uploadArtifact.ts
@@ -17,6 +17,8 @@ type UploadArtifactOptions = {
   settingsFile: FileOrBuffer
   pkFile: FileOrBuffer
   organizationId: string
+  accessToken?: string
+  apiKey?: string
   url?: string // Making url optional
 }
 
@@ -29,6 +31,8 @@ type UploadArtifactOptions = {
  *   - `settingsFile` The settings file as a Buffer or File.
  *   - `pkFile` The pk file as a Buffer or File.
  *   - `organizationId` The ID of the organization.
+ *   - `accessToken` (optional) The access token obtained after the oauth2 authorization flow
+ *   - `apiKey` (optional) The API Key created by a user
  *   - `url` (optional) The endpoint URL. Defaults to GQL_URL if not provided.
  * @returns An object containing the id of the uploaded artifact.
  * @throws If there is an error in the request or validation process.
@@ -41,6 +45,8 @@ export default async function uploadArtifact({
   settingsFile,
   pkFile,
   organizationId,
+  accessToken,
+  apiKey,
   url = GQL_URL,
 }: UploadArtifactOptions) {
   const validatedName = z.string().parse(name)
@@ -50,6 +56,8 @@ export default async function uploadArtifact({
   const validatedPkFile = fileOrBufferSchema.parse(pkFile)
   const validatedOrganizationId = uuidSchema.parse(organizationId)
   const validatedUrl = urlSchema.parse(url)
+  let validatedAccessToken = null
+  let validatedApiKey = null
 
   const operations = {
     query: UPLOAD_ARTIFACTE_MUTATION,
@@ -76,11 +84,23 @@ export default async function uploadArtifact({
   body.append('settings', new Blob([validatedSettingsFile]))
   body.append('pk', new Blob([validatedPkFile]))
 
+  const headers = new Headers()
+
+  if (accessToken) {
+    validatedAccessToken = z.string().parse(accessToken)
+    headers.append('Authorization', `Bearer ${validatedAccessToken}`)
+  }
+  if (apiKey) {
+    validatedApiKey = z.string().parse(apiKey)
+    headers.append('API-Key', validatedApiKey)
+  }
+
   try {
     const uploadArtifactResponse = await request<unknown>(validatedUrl, {
       unwrapData: true,
       method: 'POST',
       body,
+      headers,
     })
 
     const validatedUploadArtifactResponse = uploadArtifactSchema.parse(

--- a/src/utils/authHeaders.ts
+++ b/src/utils/authHeaders.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod'
+
+export default function authHeaders(
+  apiKey: string | null,
+  accessToken: string | null,
+): Headers {
+  const headers = new Headers()
+  let validatedAccessToken = ''
+  let validatedApiKey = ''
+
+  if (accessToken) {
+    validatedAccessToken = z.string().parse(accessToken)
+    headers.append('Authorization', `Bearer ${validatedAccessToken}`)
+  }
+  if (apiKey) {
+    validatedApiKey = z.string().parse(apiKey)
+    headers.append('API-Key', validatedApiKey)
+  }
+
+  return headers
+}


### PR DESCRIPTION
Changes:
1. Add `accessToken` and `apiKey` field to gated endpoints